### PR TITLE
Fix: 프래그먼트 이동해도 텍스트 유실되지 않게 수정

### DIFF
--- a/app/src/main/java/com/umc/upstyle/CreateRequestFragment.kt
+++ b/app/src/main/java/com/umc/upstyle/CreateRequestFragment.kt
@@ -9,11 +9,14 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.umc.upstyle.data.viewmodel.RequestViewModel
 import com.umc.upstyle.databinding.FragmentCreateRequestBinding
 import java.io.File
 import java.text.SimpleDateFormat
@@ -26,10 +29,26 @@ class CreateRequestFragment : Fragment() {
 
     private var photoUri: Uri? = null // ✅ lateinit 제거 및 nullable 변경
 
+    private lateinit var viewModel: RequestViewModel
+    private lateinit var editTextTitle: EditText
+    private lateinit var editTextContent: EditText
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         _binding = FragmentCreateRequestBinding.inflate(inflater, container, false)
+
+        editTextTitle = binding.etTitle
+        editTextContent = binding.etContent
+
+
+        // ViewModel 가져오기
+        viewModel = ViewModelProvider(requireActivity()).get(RequestViewModel::class.java)
+
+        // ViewModel에 저장된 데이터가 있으면 복원
+        editTextTitle.setText(viewModel.requestTitle)
+        editTextContent.setText(viewModel.requestContent)
+
         return binding.root
     }
 

--- a/app/src/main/java/com/umc/upstyle/CreateVoteFragment.kt
+++ b/app/src/main/java/com/umc/upstyle/CreateVoteFragment.kt
@@ -9,11 +9,14 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.umc.upstyle.data.viewmodel.PostViewModel
 import com.umc.upstyle.databinding.FragmentCreateVoteBinding
 import java.io.File
 import java.text.SimpleDateFormat
@@ -26,15 +29,32 @@ class CreateVoteFragment : Fragment() {
 
     private var photoUri: Uri? = null // ✅ lateinit 제거 및 nullable 변경
 
+    private lateinit var viewModel: PostViewModel
+    private lateinit var editTextTitle: EditText
+    private lateinit var editTextContent: EditText
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         _binding = FragmentCreateVoteBinding.inflate(inflater, container, false)
+        editTextTitle = binding.etTitle
+        editTextContent = binding.etContent
+
+
+        // ViewModel 가져오기
+        viewModel = ViewModelProvider(requireActivity()).get(PostViewModel::class.java)
+
+        // ViewModel에 저장된 데이터가 있으면 복원
+        editTextTitle.setText(viewModel.postTitle)
+        editTextContent.setText(viewModel.postContent)
+
+
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
 
         val preferences = requireActivity().getSharedPreferences("AppData", Context.MODE_PRIVATE)
 

--- a/app/src/main/java/com/umc/upstyle/data/viewmodel/PostViewModel.kt
+++ b/app/src/main/java/com/umc/upstyle/data/viewmodel/PostViewModel.kt
@@ -1,0 +1,8 @@
+package com.umc.upstyle.data.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class PostViewModel : ViewModel() {
+    var postTitle: String = ""
+    var postContent: String = ""
+}

--- a/app/src/main/java/com/umc/upstyle/data/viewmodel/RequestViewModel.kt
+++ b/app/src/main/java/com/umc/upstyle/data/viewmodel/RequestViewModel.kt
@@ -1,0 +1,8 @@
+package com.umc.upstyle.data.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class RequestViewModel : ViewModel() {
+    var requestTitle: String = ""
+    var requestContent: String = ""
+}

--- a/app/src/main/res/layout/fragment_create_request.xml
+++ b/app/src/main/res/layout/fragment_create_request.xml
@@ -79,6 +79,7 @@
                 android:layout_height="wrap_content">
 
                 <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@null"
@@ -108,7 +109,7 @@
             tools:ignore="MissingConstraints">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_text"
+                android:id="@+id/et_content"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"

--- a/app/src/main/res/layout/fragment_create_vote.xml
+++ b/app/src/main/res/layout/fragment_create_vote.xml
@@ -79,6 +79,7 @@
                 android:layout_height="wrap_content">
 
                 <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@null"
@@ -108,19 +109,19 @@
             tools:ignore="MissingConstraints">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_text"
+                android:id="@+id/et_content"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"
+                android:gravity="top|start"
                 android:hint="내용을 입력해주세요.(10자 이상)"
                 android:padding="10dp"
                 android:textColorHint="#66FFFFFF"
                 android:textSize="12sp"
-                android:gravity="top|start"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            
+
         </com.google.android.material.textfield.TextInputLayout>
 
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
커뮤니티 기능 CreateVoteFragment와 CreateRequestFragment에 ViewModel을 적용하여 InputText가 유실되지 않게 수정했습니다.


## 📚 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


## 🔥 테스트 결과
<!---- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 첨부해주세요. -->
